### PR TITLE
TaskSwitcher: add 2 news options (show the process name before the task name and show app icons)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ license, which you can find in the `LICENSE` file located in this directory.
   - Patch to allow predefined searches in the `Everything` package
 * [@ueffel](https://github.com/ueffel):
   - Patch to add `Copy...` actions for the `RegBrowser` package
+* [@AngelEzquerra](https://github.com/AngelEzquerra):
+  - Patch to add TaskSwitcher option to show the process name before the task name
+  - Patch to add TaskSwitcher option to show the app icons

--- a/TaskSwitcher/taskswitcher.ini
+++ b/TaskSwitcher/taskswitcher.ini
@@ -22,6 +22,14 @@
 # * Default: no
 #always_suggest = no
 
+# Show the process name before or after the task name
+# * Enabling this option makes Keypirinha sort the windows belonging to the
+#   same application together.
+# * Another advantage of enabling this option is that it also makes it easier
+#   to search for the windows belonging to an app first, and then narrow the
+#   search down by typing part of the window title.
+# * Default: no
+#proc_name_first = no
 
 [var]
 # As in every Keypirinha's configuration file, you may optionally include a

--- a/TaskSwitcher/taskswitcher.py
+++ b/TaskSwitcher/taskswitcher.py
@@ -14,10 +14,12 @@ class TaskSwitcher(kp.Plugin):
 
     DEFAULT_ITEM_LABEL = "Switch To"
     DEFAULT_ALWAYS_SUGGEST = False
+    DEFAULT_PROC_NAME_FIRST = False
     KEYWORD = "switchto"
 
     item_label = DEFAULT_ITEM_LABEL
     always_suggest = DEFAULT_ALWAYS_SUGGEST
+    proc_name_first = DEFAULT_PROC_NAME_FIRST
 
     def __init__(self):
         super().__init__()
@@ -74,7 +76,10 @@ class TaskSwitcher(kp.Plugin):
             item_short_desc = "{}: {}".format(self.item_label, wnd_title)
             if proc_image is not None:
                 proc_name = os.path.splitext(os.path.basename(proc_image))[0]
-                item_label += " (" + proc_name + ")"
+                if self.proc_name_first:
+                    item_label = proc_name + ": " + item_label
+                else:
+                    item_label += " (" + proc_name + ")"
                 item_short_desc += " (" + proc_name + ")"
 
             # if user_input is empty, just match everything we get
@@ -114,6 +119,8 @@ class TaskSwitcher(kp.Plugin):
             "item_label", "main", self.DEFAULT_ITEM_LABEL)
         self.always_suggest = settings.get_bool(
             "always_suggest", "main", self.DEFAULT_ALWAYS_SUGGEST)
+        self.proc_name_first = settings.get_bool(
+            "proc_name_first", "main", self.DEFAULT_PROC_NAME_FIRST)
 
     def _create_keyword_item(self, label, short_desc):
         return self.create_item(


### PR DESCRIPTION
Add a couple of new options:

1. proc_name_first: option to configure whether the process name must be shown before or after the task name.

Enabling this option makes Keypirinha sort the windows belonging to the same application together.

Another advantage of enabling this option is that it also makes it easier to search for the windows belonging to an app first, and then narrow the search down by typing part of the window title.

The option is disabled by default (i.e. the original behavior is maintained).

2. show_app_icons: when enabled (the default) show the application icon for each item
