### PR TITLE
Edge Bookmarks support

### DIFF
--- a/Bookmarks/bookmarks.ini
+++ b/Bookmarks/bookmarks.ini
@@ -104,6 +104,10 @@
 # * Default: empty, which means you want to rely on automatic detection
 #bookmarks_files =
 
+[provider/Edge]
+# Should bookmarks from the Edge browser be referenced?
+# Default: yes
+#enable = yes
 
 [provider/Firefox]
 # Should bookmarks from the Firefox browser be referenced?
@@ -121,7 +125,6 @@
 #   (one per line); which don't have to be named "places.sqlite".
 # * Default: empty, which means you want to rely on automatic detection
 #places_files =
-
 
 [provider/InternetExplorer]
 # Should bookmarks from the Internet Explorer browser be referenced?

--- a/Bookmarks/providers/__init__.py
+++ b/Bookmarks/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from ._base import Bookmark
 from .chrome import ChromeProvider, ChromeCanaryProvider, ChromiumProvider
+from .edge import EdgeProvider
 from .firefox import FirefoxProvider
 from .iexplorer import InternetExplorerProvider
 from .iridium import IridiumProvider

--- a/Bookmarks/providers/edge.py
+++ b/Bookmarks/providers/edge.py
@@ -1,0 +1,40 @@
+# Keypirinha: a fast launcher for Windows (keypirinha.com)
+
+import pyesedb
+import keypirinha_util as kpu
+import os.path
+from ._base import Bookmark, BookmarksProviderBase
+
+class EdgeProvider(BookmarksProviderBase):
+    localappdata_dir = None
+
+    SPARTAN_FILE_LOCATION = r"\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AC\MicrosoftEdge\User\Default\DataStore" \
+                            r"\Data\nouser1\120712-0049\DBStore\spartan.edb"
+
+    #EDB structure
+    FAVORITES_TABLE_NAME = "Favorites"
+    TITLE_COLUMN = 17
+    URL_COLUMN = 18
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        try:
+            self.localappdata_dir = kpu.shell_known_folder_path(
+                                    "{f1b32785-6fba-4fcf-9d55-7b8e7f157091}")
+        except OSError:
+            self.plugin.warn("Failed to get LocalAppData directory!")
+
+    def list_bookmarks(self):
+        bookmarks = []
+        with open(self.localappdata_dir + self.SPARTAN_FILE_LOCATION, 'rb') as spartan_file:
+            esedb_file = pyesedb.file()
+            esedb_file.open_file_object(spartan_file)
+            favorites_table = esedb_file.get_table_by_name(self.FAVORITES_TABLE_NAME)
+            for i in range(favorites_table.get_number_of_records()):
+                rec = favorites_table.get_record(i)
+                bookmarks.append(Bookmark(self.label,
+                                          rec.get_value_data_as_string(self.TITLE_COLUMN),
+                                          rec.get_value_data_as_string(self.URL_COLUMN)))
+            esedb_file.close()
+
+        return bookmarks

--- a/Bookmarks/providers/edge.py
+++ b/Bookmarks/providers/edge.py
@@ -8,7 +8,7 @@ from ._base import Bookmark, BookmarksProviderBase
 class EdgeProvider(BookmarksProviderBase):
     localappdata_dir = None
 
-    SPARTAN_FILE_LOCATION = r"\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AC\MicrosoftEdge\User\Default\DataStore" \
+    SPARTAN_FILE_LOCATION = r"Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\AC\MicrosoftEdge\User\Default\DataStore" \
                             r"\Data\nouser1\120712-0049\DBStore\spartan.edb"
 
     #EDB structure
@@ -26,15 +26,17 @@ class EdgeProvider(BookmarksProviderBase):
 
     def list_bookmarks(self):
         bookmarks = []
-        with open(self.localappdata_dir + self.SPARTAN_FILE_LOCATION, 'rb') as spartan_file:
-            esedb_file = pyesedb.file()
-            esedb_file.open_file_object(spartan_file)
-            favorites_table = esedb_file.get_table_by_name(self.FAVORITES_TABLE_NAME)
-            for i in range(favorites_table.get_number_of_records()):
-                rec = favorites_table.get_record(i)
-                bookmarks.append(Bookmark(self.label,
-                                          rec.get_value_data_as_string(self.TITLE_COLUMN),
-                                          rec.get_value_data_as_string(self.URL_COLUMN)))
-            esedb_file.close()
-
+        try:
+            with open(os.path.join(self.localappdata_dir, self.SPARTAN_FILE_LOCATION), 'rb') as spartan_file:
+                esedb_file = pyesedb.file()
+                esedb_file.open_file_object(spartan_file)
+                favorites_table = esedb_file.get_table_by_name(self.FAVORITES_TABLE_NAME)
+                for i in range(favorites_table.get_number_of_records()):
+                    rec = favorites_table.get_record(i)
+                    bookmarks.append(Bookmark(self.label,
+                                              rec.get_value_data_as_string(self.TITLE_COLUMN),
+                                              rec.get_value_data_as_string(self.URL_COLUMN)))
+                esedb_file.close()
+        except IOError as e:
+            self.plugin.warn("Failed to get Edge bookmarks: {0}".format(str(e)))
         return bookmarks


### PR DESCRIPTION
Hey, this is an implementation of Edge browser bookmarks support.

The bookmarks are stored in ESE DB, which seems to be kind of single-user. That means an user won't be able to refresh catalog while Edge instance is running. In such a case Permission denied warning message will occur in console.

I've used libesedb library (https://github.com/libyal/libesedb), so I need you to add it to the core app & update the credits of course. I'm attaching both 32-bit and 64-bit dlls to this comment, so you may use them if you want to save some time.
[pyesedb.zip](https://github.com/Keypirinha/Packages/files/2095696/pyesedb.zip)

