### PR TITLE
Add MDN documentation as a predefined site

### DIFF
--- a/WebSearch/websearch.ini
+++ b/WebSearch/websearch.ini
@@ -177,6 +177,10 @@ history_keep = all
 [predefined_site/GitHub]
 url = https://github.com/search?q=%s
 
+[predefined_site/MDN]
+url = https://developer.mozilla.org/search?q=%s
+history_keep = all
+
 [predefined_site/MSDN]
 # MSDN's own search engine is so bad that Google gives better results when
 # searching for specific Win32 APIs...


### PR DESCRIPTION
Since they now receive contributions by multiple browser vendors, the MDN pages are becoming the best source for documentation on web technologies.