### PR TITLE
Add Falkon (formerly QupZilla) support to Bookmarks package

### DIFF
--- a/Bookmarks/bookmarks.ini
+++ b/Bookmarks/bookmarks.ini
@@ -105,6 +105,24 @@
 #bookmarks_files =
 
 
+[provider/Falkon]
+# Should bookmarks from the Falkon browser be referenced?
+# Default: yes
+#enable = yes
+
+# By default, this provider will scan the directory(ies) known to be the one
+# that are used by this browser to store your bookmarks. However, since this
+# detection mechanism is not based on rocket science and given that that browser
+# may evolve and change the location of its user data, it is possible to
+# manually specify the location of the "bookmarks.json" file, used by this
+# browser to store your bookmarks.
+# * Expected value: the full path to the "bookmarks.json" file. This setting
+#   accepts multi-line value so you may specify several "bookmarks" files (one
+#   per line); which don't have to be named "bookmarks.json".
+# * Default: empty, which means you want to rely on automatic detection
+#bookmarks_files =
+
+
 [provider/Firefox]
 # Should bookmarks from the Firefox browser be referenced?
 # Default: yes

--- a/Bookmarks/providers/__init__.py
+++ b/Bookmarks/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from ._base import Bookmark
 from .chrome import ChromeProvider, ChromeCanaryProvider, ChromiumProvider
+from .falkon import FalkonProvider
 from .firefox import FirefoxProvider
 from .iexplorer import InternetExplorerProvider
 from .iridium import IridiumProvider

--- a/Bookmarks/providers/chrome.py
+++ b/Bookmarks/providers/chrome.py
@@ -10,6 +10,7 @@ class ChromeProviderBase(BookmarksProviderBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.filename = "Bookmarks"
         try:
             self.localappdata_dir = kpu.shell_known_folder_path(
                                     "{f1b32785-6fba-4fcf-9d55-7b8e7f157091}")
@@ -40,7 +41,7 @@ class ChromeProviderBase(BookmarksProviderBase):
 
                 for profile_dir in profile_dirs:
                     bookmarks += self._read_bookmarks(os.path.join(
-                                        chrome_dir, profile_dir, "Bookmarks"))
+                                        chrome_dir, profile_dir, self.filename))
         return bookmarks
 
     def _read_bookmarks(self, bookmarks_file):

--- a/Bookmarks/providers/falkon.py
+++ b/Bookmarks/providers/falkon.py
@@ -1,0 +1,16 @@
+# Keypirinha: a fast launcher for Windows (keypirinha.com)
+
+import os.path
+from .chrome import ChromeProviderBase
+
+class FalkonProvider(ChromeProviderBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.filename = "bookmarks.json"
+
+    def profile_dir_candidates(self):
+        candidates = []
+        if self.localappdata_dir:
+            candidates.append(os.path.join(
+                self.localappdata_dir, "falkon", "profiles"))
+        return candidates


### PR DESCRIPTION
Add Falkon provider. Falkon is an open-source browser built on Qt WebEngine (a wrapper for Chromium).

Unlike other Chromium browsers, Falkon calls bookmarks file `bookmarks.json` instead of `Bookmarks`. So I've made a small change in `ChromeProviderBase` to be able to inherit it. 