### PR TITLE
Added directory browsing functionality to FilesCatalog.

### DIFF
--- a/FilesCatalog/filescatalog.ini
+++ b/FilesCatalog/filescatalog.ini
@@ -21,6 +21,25 @@
 # * Default: no
 #debug = no
 
+[browsing]
+# These values affect only the in-launcher directory browsing behaviour for this
+# plugin's suggested items. The catalog will not be affected by this section.
+
+# Show directories first while browsing
+# Default: yes
+#show_dirs_first = yes
+
+# Show hidden files while browsing
+# Default: no
+#show_hidden_files = no
+
+# Show system files while browsing
+# * Note that system files/directories may be hidden. In other words, some
+#   files/dirs setting may still not be visible unless you set show_hidden_files
+#   to "yes" as well.
+# * Default: no
+#show_system_files = no
+
 
 [profile/ExeOnly]
 # A helper base profile to inherit from in order to catalog executable files


### PR DESCRIPTION
Following @polyvertex's [suggestion](https://github.com/Keypirinha/Keypirinha/issues/270#issuecomment-357174844) on [Keypirinha #277](https://github.com/Keypirinha/Keypirinha/issues/270), I have used the FileBrowser's source code as a template to replicate the directory browsing behaviour in FilesCatalog's items.

From the FileBrowser's source code I couldn't tell if most of the user_input checks were done solely for populating the suggestions or if they were also necessary for creating the browsing functionality in some edge cases. So I decided to implement directory browsing only in cases where the file is explicitly a folder or a link to a folder.

A new section, 'browsing', was added to filescatalog.ini to control the new browsing functionality. This created an unexpected issue: when these new settings are changed the filefilter library throws an error. It seems that changing these configurations has the side effect of changing the hash of some filters. To avoid this, I have set the config_changed flag to True whenever any of the 'browsing' settings is changed. This triggers an unnecessary recataloging which ideally should be avoided, but I could not find a proper way around it.