### PR TITLE
Added 'Unescape' functor for Strings module

### DIFF
--- a/String/string.py
+++ b/String/string.py
@@ -130,10 +130,10 @@ class _Functor_CaseConversion(_Functor):
 
         splits = [m.span()[0] for m in re.finditer('[A-Z]+[a-z0-9]*', ascii_data)]+[len(ascii_data)]
         splits = [0] + splits if splits[0] != 0 else splits
-        
+
         need_prefix = lambda splits, split: split > 0 and data[splits[split]-1].isalnum()
         do_prefix = lambda word, splits, split: (delim if need_prefix(splits,split) else "") + word
-        
+
         return "".join([do_prefix(data[splits[split]:splits[split+1]].lower(),splits,split) for split in range(len(splits)-1)])
 
     # Snake casing  converts AboveAverage to above-average
@@ -346,6 +346,22 @@ class _Functor_Reverse(_Functor):
     def convert(self, data):
         return [{'label': data[::-1], 'target': data[::-1], 'desc': 'Reversed string'}]
 
+class _Functor_Unescape(_Functor):
+    def __init__(self):
+        super().__init__("unescape", "Un-escape",
+                         "Un-escape a backslash-escaped string")
+
+    def convert(self, data):
+        # another method:
+        # escaped = data.encode('utf-8').decode('unicode_escape')
+
+        try:
+            escaped = codecs.decode(codecs.encode(data, 'latin-1', 'backslashreplace'), 'unicode-escape')
+        except UnicodeDecodeError as e:
+            return []
+
+        return [{'label': escaped, 'target': escaped, 'desc': 'Un-escaped string'}]
+
 class String(kp.Plugin):
     """
     A multi-purpose plugin for string conversion and generation
@@ -391,7 +407,8 @@ class String(kp.Plugin):
             _Functor_ZLib("adler32"),
             _Functor_ZLib("crc32"),
             _Functor_Base64(),
-            _Functor_Reverse()]
+            _Functor_Reverse(),
+            _Functor_Unescape()]
 
         for algo in hashlib.algorithms_available:
             # some algorithms are declared twice in the list, like 'MD4' and


### PR DESCRIPTION
Decode escaped string

Example:
\> "{\\"hello\\": \\"world\\"}
< "{"hello": "world"}

https://stackoverflow.com/questions/1885181/how-to-un-escape-a-backslash-escaped-string
https://www.freeformatter.com/json-escape.html
