### PR TITLE
WinSCP: Add setting for using a custom configuration file

### DIFF
--- a/WinSCP/winscp.ini
+++ b/WinSCP/winscp.ini
@@ -14,8 +14,8 @@
 # Once WinSCP has been found, the plugin will reference one or several "WinSCP"
 # items: one for the executable itself, plus one for each configured WinSCP
 # session found in its system registry key
-# "HKEY_CURRENT_USER\Software\Martin Prikryl\WinSCP 2" or its configuration
-# file "WinSCP.ini".
+# "HKEY_CURRENT_USER\Software\Martin Prikryl\WinSCP 2", its configuration
+# file "WinSCP.ini" or the configuration file provided below.
 
 # Allow this version of WinSCP to be referenced.
 # * If this value is false (i.e.: "no"; without quotes), the plugin will not
@@ -45,6 +45,23 @@
 #   * If not found, auto-detection is aborted
 # * Default: empty value
 #path =
+
+# The path to a WinSCP configuration file.
+# * This value can be empty or a path to any valid WinSCP configuration (INI)
+#   file.
+# * If this value is empty, the plugin will try to automatically detect where
+#   a valid configuration file is available.
+# * The auto-detection steps are as follows:
+#   * Check if this value is set and the file is found. If so, use it.
+#   * If not, search for a "WinSCP.ini" file next to the "WinSCP.exe"
+#     executable file.
+#   * If not found, search for a "WinSCP.ini" file in
+#     "%USERPROFILE%\AppData\Roaming".
+#   * If not found, search for session names in this path in Windows Registry:
+#     'HKEY_CURRENT_USER/Software/Martin Prikryl/WinSCP 2/Sessions'.
+#   * If not found, auto-detection is aborted
+# * Default: empty value
+#ini_path =
 
 
 [var]


### PR DESCRIPTION
Added a `ini_path` value in settings to load sessions from a custom configuration (*.INI) file.

One caveat is that using the `ini_path` option disables all auto-detection of installed/portable configurations. The problem of not doing so is that any conflicts in session names will overwrite each other and go unnoticed.

Fixes Keypirinha/Keypirinha#263