### PR TITLE
Extend FilesCatalog profiles to open items with a custom command

### DIFF
--- a/FilesCatalog/filescatalog.ini
+++ b/FilesCatalog/filescatalog.ini
@@ -406,6 +406,16 @@ dir_item_desc = ${file_item_desc}
 # * Default: .lnk
 trim_extensions = .lnk
 
+# Open the item with a custom command line
+# * Use this if you want to run a specific program when the item is opened.
+# * The value should be a valid executable, and can include parameteres; any
+#   occurrences of {} will be replaced with the item path.
+# * Examples:
+#     open_with = notepad.exe {}
+#     open_with = wt.exe -d {}
+# * Default: empty. The system default will be used
+open_with =
+
 # Custom item Python callback
 # * For very advanced users only
 # * This setting allows maximum flexibility by offering a way to implement your


### PR DESCRIPTION
[this is a draft!]

When one activates a FilesCatalog item, the file or directory is opened with the default association. With these changes, one could specify a custom command.

Some things that would become possible:
- snippet library: add a list of text files to the catalog, with a custom command which copies their content to the clipboard, e.g., `open_with = contents-to-clibboard.exe {}`
- list project directories, open a terminal there with `wt.exe -d {}`
- list repositories, pull changes with `open_with = git --git-dir={}.git pull`

I have used the `data_bag` attribute to store the custom command for an item (and bumped into https://github.com/Keypirinha/Keypirinha/issues/438). I was also wondering if Keypirinha or FilesCatalog don't allow two items with the same target, as items from "overlapping" profiles seem to appear only once.