### PR TITLE
Calc: Don't strip zeroes for scientific notation

### DIFF
--- a/Calc/calc.py
+++ b/Calc/calc.py
@@ -690,7 +690,8 @@ class Calc(kp.Plugin):
             else:
                 def do_trans(val):
                     val = str(val).translate(self.transmap_output).lower()
-                    if self.decimal_separator in val:
+                    # Strip right-most zeroes except for scientifically notated values.
+                    if self.decimal_separator in val and ('e' not in val and 'E' not in val):
                         val = val.rstrip("0").rstrip(self.decimal_separator)
                         if not len(val):
                             val = "0"


### PR DESCRIPTION
Fixes Keypirinha/Keypirinha#473.

@polyvertex, I'm not sure how this affects different kinds of decimal and thousand separators; couldn't test it with everything. But it seems to work fine with default settings in English-India locale. Since you worked on this package the most I'd appreciate if you made sure I didn't break anything.