### PR TITLE
WinSCP: Support for 'for you only' installations & other bug fixes

### DIFF
--- a/WinSCP/winscp.py
+++ b/WinSCP/winscp.py
@@ -291,8 +291,9 @@ class WinSCP(kp.Plugin):
 
     def _autodetect_startmenu(self, exe_name, name_pattern):
         known_folders = (
-            "{625b53c3-ab48-4ec1-ba1f-a1ef4146fc19}", # FOLDERID_StartMenu
-            "{a4115719-d62e-491d-aa7c-e74b8be3b067}") # FOLDERID_CommonStartMenu
+            "{625b53c3-ab48-4ec1-ba1f-a1ef4146fc19}",  # FOLDERID_StartMenu
+            "{a4115719-d62e-491d-aa7c-e74b8be3b067}",  # FOLDERID_CommonStartMenu
+            "{a77f5d77-2e2b-44c3-a6a2-aba601054a51}",) # FOLDERID_Programs
 
         found_link_files = []
         for kf_guid in known_folders:

--- a/WinSCP/winscp.py
+++ b/WinSCP/winscp.py
@@ -309,7 +309,7 @@ class WinSCP(kp.Plugin):
         for link_file in found_link_files:
             try:
                 link_props = kpu.read_link(link_file)
-                if (link_props['target'].lower().endswith(exe_name) and
+                if (link_props['target'].endswith(exe_name) and
                         os.path.exists(link_props['target'])):
                     return link_props['target']
             except Exception as exc:

--- a/WinSCP/winscp.py
+++ b/WinSCP/winscp.py
@@ -267,10 +267,10 @@ class WinSCP(kp.Plugin):
 
 
 
-    def _autodetect_official_installreg(self):
+    def _exe_from_reg(self, reg_root):
         try:
             key = winreg.OpenKey(
-                winreg.HKEY_LOCAL_MACHINE,
+                reg_root,
                 "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\winscp3_is1",
                 access=winreg.KEY_READ | winreg.KEY_WOW64_32KEY)
             value = winreg.QueryValueEx(key, "InstallLocation")[0]
@@ -281,6 +281,11 @@ class WinSCP(kp.Plugin):
         except:
             pass
         return None
+
+    def _autodetect_official_installreg(self):
+        hklm = self._exe_from_reg(winreg.HKEY_LOCAL_MACHINE)
+        return (hklm if hklm is not None
+                else self._exe_from_reg(winreg.HKEY_CURRENT_USER))
 
     def _autodetect_official_progfiles(self):
         for hive in ('%PROGRAMFILES%', '%PROGRAMFILES(X86)%'):

--- a/WinSCP/winscp.py
+++ b/WinSCP/winscp.py
@@ -283,9 +283,9 @@ class WinSCP(kp.Plugin):
         return None
 
     def _autodetect_official_installreg(self):
-        hklm = self._exe_from_reg(winreg.HKEY_LOCAL_MACHINE)
-        return (hklm if hklm is not None
-                else self._exe_from_reg(winreg.HKEY_CURRENT_USER))
+        hkcu = self._exe_from_reg(winreg.HKEY_CURRENT_USER)
+        return (hkcu if hkcu is not None
+                else self._exe_from_reg(winreg.HKEY_LOCAL_MACHINE))
 
     def _autodetect_official_progfiles(self):
         for hive in ('%PROGRAMFILES%', '%PROGRAMFILES(X86)%'):


### PR DESCRIPTION
The current auto-detection strategy for paths does not consider installations in %APPDATA%, as well as a few other bugs that get in the way. This PR makes the following changes:

- Fixes a bug in StartMenu detection which made it unusable.
- Modifies StartMenu detection to also search for the shortcut in %APPDATA%\Microsoft\Windows\Start Menu\Programs.
- Searches the registry under the HKCU root as well (for 'for you only' installations).

Fixes Keypirinha/Keypirinha#488.