### PR TITLE
WebSearch: add a `quoting = none` setting to prevent quoting/escaping in URLs altogether

### DIFF
--- a/WebSearch/websearch.ini
+++ b/WebSearch/websearch.ini
@@ -95,7 +95,9 @@
 #     * "quote": Replace special characters using the '%xx' escape. Letters,
 #       digits, and the characters '_.-' are never quoted.
 #     * "quote_plus": Like "quote", but replace spaces by plus signs.
-#     * Default: args_quoting = auto
+#     * "none": No special characters are quoted, and the arguments provided by
+#       the user are inserted into the URL exactly as the user wrote them.
+#     * Default: quoting = auto
 # * You may declare as much search site as you wish.
 
 

--- a/WebSearch/websearch.py
+++ b/WebSearch/websearch.py
@@ -109,7 +109,9 @@ class WebSearch(kp.Plugin):
 
     def _url_build(self, url_format, search_terms, quoting='auto', fallback_url=None):
         def _quote(fmt_string, search_terms, quoting):
-            if quoting == 'plus':
+            if quoting == 'none':
+                return fmt_string.replace("%s", search_terms)
+            elif quoting == 'plus':
                 return fmt_string.replace(
                     "%s", urllib.parse.quote_plus(search_terms))
             else: # if quoting == 'quote':
@@ -162,7 +164,7 @@ class WebSearch(kp.Plugin):
             'all': kp.ItemHitHint.KEEPALL,
             'site': kp.ItemHitHint.NOARGS,
             'none': kp.ItemHitHint.IGNORE}
-        supported_quoting = ['auto', 'full', 'plus']
+        supported_quoting = ['auto', 'full', 'plus', 'none']
 
         settings = self.load_settings()
 


### PR DESCRIPTION
## What

* Adds a `none` option for the `quoting` setting:
  * When this option is used, no special characters are replaced (with `%xx` escape codes), and the user-provided string is used exactly as written
  * When any other option is used, the behaviour should be exactly as before
* Fixes a typo in the comments documenting the `keysearch.ini` file, where the `quoting` setting was referred to as `args_quoting`

## Why

This is kind of a niche requirement, but I have at least one example where it's useful 😄  My use case was that I wanted to use WebSearch to look up DOIs for academic references using the [doi2bib](https://doi2bib.org/) website. DOIs typically contain slashes `/`, and doi2bib requires these to be unescaped in the URL, so

> <https://doi2bib.org/bib/10.1093/qje/qjw001>

works, but the escaped version

> <https://doi2bib.org/bib/10.1093%2Fqje%2Fqjw001>

doesn't.

After this change, I can configure this site as follows in my WebSearch config, and it behaves like I want it to:

```
[site/doi2bib]
url = https://doi2bib.org/bib/%s
quoting = none
```