### PR TITLE
RegBrowser: Support standard PowerShell format - HKCR: etc

### DIFF
--- a/RegBrowser/regbrowser.py
+++ b/RegBrowser/regbrowser.py
@@ -45,6 +45,10 @@ class RegBrowser(kp.Plugin):
                 abbr = "HK" + "".join([x[0] for x in name.split("_")][1:])
                 self.root_hkeys_dict.setdefault(abbr, value)
 
+                # standard format used by PowerShell - "HKCR:", etc.
+                abbr += ":"
+                self.root_hkeys_dict.setdefault(abbr, value)
+
                 # value to full name
                 self.root_hkeys_dict.setdefault(value, name)
 


### PR DESCRIPTION
Adds RegBrowser support for the standard PowerShell format to access the registry, such as `HKCU:\SOFTWARE\Classes\Directory\background\shell\`