### PR TITLE
WebSuggest: wrong config section used for getting default_action

### DIFF
--- a/WebSuggest/websuggest.py
+++ b/WebSuggest/websuggest.py
@@ -489,7 +489,7 @@ class WebSuggest(kp.Plugin):
 
             # default_action
             item_default_action = settings.get_enum(
-                "default_action", self.CONFIG_SECTION_MAIN,
+                "default_action", section,
                 fallback=default_action, enum=self.actions_names)
 
             # provider


### PR DESCRIPTION
Overriding the default action for an item or predefined item did not work because the wrong config section was used when retrieving the value