### PR TITLE
Bookmarks: Added option to require prefix for search

### DIFF
--- a/Bookmarks/bookmarks.ini
+++ b/Bookmarks/bookmarks.ini
@@ -6,6 +6,16 @@
 [main]
 # Plugin's main configuration section.
 
+# The title of the catalog item created by the plugin.
+# * The bookmarks appeare in different places based on the value
+#   * Empty string / only whitespaces: The bookmarks can be searched right away
+#   * Any other string: In order to be able to search amongst the bookmarks, the
+#     item with the same label as the specified string has to be selected
+# * Defining this is generally useful when there are a lot of bookmarks
+#   which can make it harder to find other items
+# * Default: ""
+#group_item_label =
+
 # The format string that will be used to name every catalog item created by this
 # plugin.
 # * It accepts the following placeholders:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ license, which you can find in the `LICENSE` file located in this directory.
 * [@AngelEzquerra](https://github.com/AngelEzquerra):
   - Patch to add the `proc_name_first` setting to the `TaskSwitcher` package
   - Patch to add the `show_app_icons` setting to the `TaskSwitcher` package
+* [@Heck-R](https://github.com/Heck-R):
+  - Added `group_item_label` setting to the `Bookmarks` package
 * [@psistorm](https://github.com/psistorm):
   - Patch to allow predefined searches in the `Everything` package
 * [@ckolumbus](https://github.com/ckolumbus):


### PR DESCRIPTION
Bookmarks can be hidden under an item with a specified label

E.g.:
- Using the new setting with the default empty value `group_item_label =` will work exactly as before
  ![image](https://user-images.githubusercontent.com/29919193/132993898-ae2ecff1-8376-43ed-a99c-aac21f533344.png)

- Using some value like `group_item_label = Bookmarks` will exclude the bookmarks from the original search options, and provide a single item instead. The bookmarks can be searched upon selecting the mentioned item
  ![image](https://user-images.githubusercontent.com/29919193/132994006-d88f0cff-bc35-49f5-8f16-4b29875432d1.png)
  ![image](https://user-images.githubusercontent.com/29919193/132994007-5fb40ba7-5b2c-47d0-94ea-d55d947c0da0.png)
