### PR TITLE
Add semicalc feature to the Calc plugin

### DIFF
--- a/Calc/calc.py
+++ b/Calc/calc.py
@@ -413,6 +413,18 @@ class Calc(kp.Plugin):
                 args_hint=kp.ItemArgsHint.REQUIRED,
                 hit_hint=kp.ItemHitHint.NOARGS)])
 
+    def semicalc(self, expression):
+        while True:
+            semipos = expression.find(";")
+            if semipos < 0:
+                return expression
+            elif semipos == 0:
+                expression = expression[1:]
+            elif len(expression) > semipos and (expression[semipos+1].isalnum() or expression[semipos+1] in "(){}[]"):
+                return f"error: {expression}"
+            else:
+                expression = f"({expression[0:semipos]}){expression[semipos+1:]}"
+
     def on_suggest(self, user_input, items_chain):
         if items_chain and items_chain[0].category() == self.ITEMCAT_VAR:
             suggestions = []
@@ -447,7 +459,7 @@ class Calc(kp.Plugin):
 
         suggestions = []
         try:
-            results = self._eval(expression)
+            results = self._eval(self.semicalc(expression))
             if not isinstance(results, (tuple, list)):
                 results = (results,)
             for res in results:

--- a/Calc/calc.py
+++ b/Calc/calc.py
@@ -420,6 +420,8 @@ class Calc(kp.Plugin):
                 return expression
             elif semipos == 0:
                 expression = expression[1:]
+            elif semipos + 1 == len(expression):
+                expression = expression[0:-1]
             elif len(expression) > semipos and (expression[semipos+1].isalnum() or expression[semipos+1] in "(){}[]"):
                 return f"error: {expression}"
             else:

--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ license, which you can find in the `LICENSE` file located in this directory.
 * [@DrorHarari](https://github.com/DrorHarari):
   - Patch to add string reverse and camel-like case changes to the `String` package
   - Patch to add variable support to the 'Calc' package
+  - Patch to add multi-part calculation to the 'Calc' package (10+20+30;*1.3)


### PR DESCRIPTION
Add semicalc (multi-part calculation) feature to the Calc plugin.

For example, writing "10+20+30;*1.3" is equivalent to "(10+20+30)*1.3"

Every semicolon is replaced with the preceding part of the expression, wrapped in parentheses.

Refer to issue https://github.com/Keypirinha/Keypirinha/issues/526